### PR TITLE
hoftix: html string 응닶값 div -> p태그로 감싸는 것으로 변경

### DIFF
--- a/src/components/common/home/contents/latest/HomeLatestcontent.tsx
+++ b/src/components/common/home/contents/latest/HomeLatestcontent.tsx
@@ -52,10 +52,10 @@ export default function HomeLatestcontent() {
           <h2 className='mb-1 line-clamp-2 text-lg font-medium leading-[150%] tracking-[-2%] text-custom-black'>
             {content?.title}
           </h2>
-          <div
+          <p
             dangerouslySetInnerHTML={{ __html: content?.summaryText ?? '' }}
             className='mb-2 line-clamp-3 h-[60px] text-sm leading-[150%] tracking-[-2%] text-custom-gray-dark'
-          ></div>
+          />
           <ScrapDateNCount
             date={formatDate(content?.createdAt!)}
             scrapCount={content?.viewCount!}

--- a/src/components/common/home/contents/popular/HomePopularContents.tsx
+++ b/src/components/common/home/contents/popular/HomePopularContents.tsx
@@ -38,10 +38,10 @@ export default function HomePopularContents() {
                   {item.title}
                 </h2>
               </div>
-              <div
+              <p
                 dangerouslySetInnerHTML={{ __html: item.summaryText }}
                 className='mb-2 line-clamp-3 h-[60px] w-full text-sm tracking-[-2%] text-custom-black'
-              ></div>
+              />
               <ScrapDateNCount date={formatDate(item.createdAt)} scrapCount={item.viewCount} />
             </div>
           </Link>

--- a/src/components/contentDetail/ScriptWithTime.tsx
+++ b/src/components/contentDetail/ScriptWithTime.tsx
@@ -69,7 +69,7 @@ export default function ScriptWithTime({
       >
         {time}
       </button>
-      <div
+      <p
         dangerouslySetInnerHTML={{ __html: script }}
         className='text-custom-gray-dark md:text-sm md:leading-170'
       />

--- a/src/components/contentList/ContentListCard.tsx
+++ b/src/components/contentList/ContentListCard.tsx
@@ -29,10 +29,10 @@ export default function ContentListCard({
         <div className='min-h-[52px] w-[254px]'>
           <h2 className='mb-1 mt-2 line-clamp-2 text-lg font-medium'>{title}</h2>
         </div>
-        <div
+        <p
           dangerouslySetInnerHTML={{ __html: summaryText }}
           className='mb-2 line-clamp-3 max-h-[70px] w-full leading-[150%] text-custom-black md:text-sm'
-        ></div>
+        />
         <ScrapDateNCount date={formatDate(createdAt)} scrapCount={viewCount} />
       </div>
     </Link>

--- a/src/components/myScrap/content/ScrapedContents.tsx
+++ b/src/components/myScrap/content/ScrapedContents.tsx
@@ -36,7 +36,7 @@ export default function ScrapedContents({ contentList }: { contentList: ScrapedC
                   {content.contentTitle}
                 </p>
                 <div className='hidden md:mb-2 md:block'>
-                  <div
+                  <p
                     dangerouslySetInnerHTML={{ __html: content.summaryText }}
                     className='line-clamp-2 desktop:line-clamp-3'
                   />


### PR DESCRIPTION
- html string 응닶값 div -> p태그로 감싸는 것으로 변경: 인기 콘텐츠, 최신 콘텐츠 및 상세 페이지내 적용