### PR TITLE
hotfix: 핵심 요약 html string으로 받는 부분 div -> p 태그로 변경

### DIFF
--- a/src/components/contentDetail/ContentSummary.tsx
+++ b/src/components/contentDetail/ContentSummary.tsx
@@ -2,7 +2,7 @@ export default function ContentSummary({ summary }: { summary: string }) {
   return (
     <div className='mb-5 flex w-full flex-col gap-y-1 leading-170 text-custom-gray-dark md:text-sm desktop:flex-row desktop:gap-x-6'>
       <span className='whitespace-nowrap font-medium desktop:mt-0.5'>💡 핵심 요약</span>
-      <div
+      <p
         dangerouslySetInnerHTML={{ __html: summary }}
         className='leading-170 md:text-sm md:leading-170 desktop:w-[533px]'
       />


### PR DESCRIPTION
- 핵심 요약 html string으로 받는 부분 div -> p 태그로 변경