### PR TITLE
fix: 뉴스 카드 데이터 호출하는 수 변경

### DIFF
--- a/src/hooks/dashboard/useDashboard.ts
+++ b/src/hooks/dashboard/useDashboard.ts
@@ -5,7 +5,7 @@ import useNewsList from './useNewsList';
 export default function useDashboard() {
   const { showOnboarding, setShowOnboarding } = useOnboardingStore();
   const { latestNews } = useLatestNews();
-  const { newsList } = useNewsList();
+  const { newsList } = useNewsList(null, 4);
   const latestNewsId = latestNews ? latestNews.newsId : 0;
 
   return { showOnboarding, setShowOnboarding, latestNews, newsList, latestNewsId };

--- a/src/hooks/newsList/useNewsListLogic.ts
+++ b/src/hooks/newsList/useNewsListLogic.ts
@@ -8,7 +8,7 @@ import useCheckFirstQuiz from '../dashboard/useCheckFirstQuiz';
 import { useState } from 'react';
 
 export default function useNewsListLogic() {
-  const { newsList } = useNewsList();
+  const { newsList } = useNewsList(null, 10);
   const { latestNews } = useLatestNews();
   const { isLogin } = useLoginStore();
   const navigate = useNavigate();


### PR DESCRIPTION
- 대시보드 페이지 인기뉴스 카드 데이터 4개로 고정
- 머니 뉴스 페이지 목록 10개만 호출