### PR TITLE
fix: 대시보드 이슈 해결 및 나의 단어장 페이지 쿼리 무효화

### DIFF
--- a/src/components/common/Keywords.tsx
+++ b/src/components/common/Keywords.tsx
@@ -22,7 +22,7 @@ export default function Keywords({
             <span className='whitespace-nowrap'>#{tag}</span>
 
             <p
-              className={`absolute -left-7 -top-2.5 z-[999] -translate-y-full whitespace-nowrap rounded bg-custom-gray-dark px-2.5 py-2 text-xs text-custom-cream-light drop-shadow-md after:absolute after:left-8 after:top-full after:border-x-[6px] after:border-t-[8px] after:border-transparent after:border-t-custom-gray-dark after:content-[''] ${withTooltip && showTooltip && index === 0 ? 'block' : 'hidden'}`}
+              className={`absolute -left-7 -top-2.5 z-[999] -translate-y-full whitespace-nowrap rounded bg-custom-gray-dark px-2.5 py-2 text-xs text-custom-cream-light after:absolute after:left-8 after:top-full after:border-x-[6px] after:border-t-[8px] after:border-transparent after:border-t-custom-gray-dark after:content-[''] ${withTooltip && showTooltip && index === 0 ? 'block' : 'hidden'}`}
             >
               해당 머니뉴스를 통해 공부할 수 있는 단어에요.
             </p>

--- a/src/hooks/dashboard/useCheckFirstVisit.ts
+++ b/src/hooks/dashboard/useCheckFirstVisit.ts
@@ -1,6 +1,6 @@
-import { useEffect, Dispatch, SetStateAction } from 'react';
+import { useEffect } from 'react';
 
-export default function useCheckFirstVisit(setShowOnboarding: Dispatch<SetStateAction<boolean>>) {
+export default function useCheckFirstVisit(setShowOnboarding: (onBoardingStatus: boolean) => void) {
   useEffect(() => {
     const isFirstVisit = localStorage.getItem('hasSeenOnboarding');
 

--- a/src/hooks/dashboard/useOnboarding.ts
+++ b/src/hooks/dashboard/useOnboarding.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-// import useCheckFirstVisit from './useCheckFirstVisit';
+import useCheckFirstVisit from './useCheckFirstVisit';
 import useKeywordTooltip from '@/store/useKeywordTooltip';
 import useDisableScroll from '../common/useDisableScroll';
 
@@ -13,7 +13,7 @@ export default function useOnboarding({
   setShowOnboarding: (onBoardingStatus: boolean) => void;
 }) {
   const [currentStep, setCurrentStep] = useState(0);
-  // useCheckFirstVisit(setShowOnboarding);
+  useCheckFirstVisit(setShowOnboarding);
 
   const { setShowTooltip } = useKeywordTooltip();
   useDisableScroll(showOnboarding);

--- a/src/hooks/myWordList/api/useGetWordListData.ts
+++ b/src/hooks/myWordList/api/useGetWordListData.ts
@@ -1,13 +1,13 @@
 import { useLoginStore } from '@/store/useIsLoginStore';
 import wordListAPi from '@/services/wordListApi';
-
+import { useQueryClient } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import { MyWordListMenuType } from '@/types/types';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 
 export default function useGetWordListData(activeMenu: MyWordListMenuType) {
   const { isLogin } = useLoginStore((state) => state);
-
+  const queryClient = useQueryClient();
   const apiFunctions: Record<MyWordListMenuType, () => Promise<any>> = {
     스크랩: wordListAPi.getScrap,
     핵심노트: wordListAPi.getKeyNote,
@@ -22,6 +22,10 @@ export default function useGetWordListData(activeMenu: MyWordListMenuType) {
     staleTime: 1000,
     refetchOnWindowFocus: false,
   });
+
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: activeMenu });
+  }, [activeMenu, queryClient]);
 
   const wordList = useMemo(() => {
     if (!data) return [];


### PR DESCRIPTION
- 뉴스 카드 툴팁 그림자 제거
- 온 보딩 첫 사용자에게만 표시되도록 하는 커스텀 훅 추가
- 나의 단어장 페이지 activeMenu가 변경될 때마다 이전 데이터를 무효화
