### PR TITLE
fix: 홈 페이지 단어 툴팁 위치 변경

### DIFF
--- a/src/components/common/Keywords.tsx
+++ b/src/components/common/Keywords.tsx
@@ -1,15 +1,6 @@
 import bookmarkIcon from '@/assets/p2/P2 에셋_2차전달/icon_bookmark_green fill22.svg';
-import useKeywords from '@/hooks/dashboard/useKeywords';
 
-export default function Keywords({
-  tags,
-  withTooltip = false,
-}: {
-  tags: string[];
-  withTooltip?: boolean;
-}) {
-  const showTooltip = useKeywords(withTooltip);
-
+export default function Keywords({ tags }: { tags: string[] }) {
   return (
     <div className='flex items-center gap-x-1.5'>
       <img src={bookmarkIcon} alt='북마크' className='icon_scrap h-[22px] w-[22px]' />
@@ -17,15 +8,9 @@ export default function Keywords({
         {tags.map((tag, index) => (
           <div
             key={index}
-            className='relative flex items-center justify-center rounded border border-custom-gray-400 p-1.5 leading-6 text-custom-gray-700 drop-shadow-md'
+            className='flex items-center justify-center rounded border border-custom-gray-400 p-1.5 leading-6 text-custom-gray-700 drop-shadow-md'
           >
             <span className='whitespace-nowrap'>#{tag}</span>
-
-            <p
-              className={`absolute -left-7 -top-2.5 z-[999] -translate-y-full whitespace-nowrap rounded bg-custom-gray-dark px-2.5 py-2 text-xs text-custom-cream-light after:absolute after:left-8 after:top-full after:border-x-[6px] after:border-t-[8px] after:border-transparent after:border-t-custom-gray-dark after:content-[''] ${withTooltip && showTooltip && index === 0 ? 'block' : 'hidden'}`}
-            >
-              해당 머니뉴스를 통해 공부할 수 있는 단어에요.
-            </p>
           </div>
         ))}
       </div>

--- a/src/components/common/NewsCard.tsx
+++ b/src/components/common/NewsCard.tsx
@@ -4,6 +4,7 @@ import { formatDate } from '@/utils/myScrapUtils';
 import Keywords from './Keywords';
 import { Link } from 'react-router-dom';
 import WaterMark from '@/assets/imgs/watermark.png';
+import useKeywords from '@/hooks/dashboard/useKeywords';
 
 export default function NewsCard({
   news,
@@ -15,6 +16,7 @@ export default function NewsCard({
   isDesktop?: boolean;
 }) {
   const { title, viewCount, createdAt, thumbnailUrl, newsId, tags } = news;
+  const showTooltip = useKeywords(isToday);
 
   return (
     <Link
@@ -34,7 +36,12 @@ export default function NewsCard({
           <span>{formatDate(createdAt)}</span>
         </div>
         <p className='mb-2 font-bold text-custom-gray-dark'>{title}</p>
-        <Keywords tags={tags} withTooltip={isToday} />
+        <Keywords tags={tags} />
+        <p
+          className={`tooltip absolute -bottom-[76px] left-0 z-[999] -translate-y-full whitespace-nowrap rounded bg-custom-gray-dark px-2.5 py-2 text-xs text-custom-cream-light ${isToday && showTooltip ? 'block' : 'hidden'}`}
+        >
+          해당 머니뉴스를 통해 공부할 수 있는 단어에요.
+        </p>
       </div>
     </Link>
   );

--- a/src/components/dashboard/Onboarding.tsx
+++ b/src/components/dashboard/Onboarding.tsx
@@ -63,7 +63,7 @@ export default function OnBoarding({
                 className={`h-1.5 w-1.5 rounded-full ${
                   index === currentStep ? 'bg-active-green' : 'bg-inactive'
                 }`}
-              ></div>
+              />
             ))}
           </div>
           <button

--- a/src/hooks/dashboard/useKeywords.ts
+++ b/src/hooks/dashboard/useKeywords.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import useKeywordTooltip from '@/store/useKeywordTooltip';
+import useKeywordTooltip from '@/store/useTooltipState';
 import { useOnboardingStore } from '@/store/useOnBoardingStore';
 
 export default function useKeywords(withTooltip: boolean) {

--- a/src/hooks/dashboard/useOnboarding.ts
+++ b/src/hooks/dashboard/useOnboarding.ts
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import useKeywordTooltip from '@/store/useKeywordTooltip';
+import useTooltipState from '@/store/useTooltipState';
 import useDisableScroll from '../common/useDisableScroll';
 
 export default function useOnboarding({
@@ -12,12 +12,16 @@ export default function useOnboarding({
   setShowOnboarding: (onBoardingStatus: boolean) => void;
 }) {
   const [currentStep, setCurrentStep] = useState(0);
-  const { setShowTooltip } = useKeywordTooltip();
+  const { setShowTooltip } = useTooltipState();
   useDisableScroll(showOnboarding);
 
   const handleNext = () => {
     if (currentStep < onboardingStepsLen - 1) {
       setCurrentStep((prev) => prev + 1);
+      if (localStorage.getItem('hasCheckedOnboarding')) {
+        setShowTooltip(true);
+        setTimeout(() => setShowTooltip(false), 3000);
+      }
     } else {
       setShowOnboarding(false);
       setShowTooltip(true);
@@ -26,7 +30,7 @@ export default function useOnboarding({
   };
   const handleCheck = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.checked) localStorage.setItem('hasCheckedOnboarding', 'true');
-    else localStorage.setItem('hasCheckedOnboarding', 'false');
+    else localStorage.removeItem('hasCheckedOnboarding');
   };
 
   return { currentStep, handleNext, setShowTooltip, handleCheck };

--- a/src/index.css
+++ b/src/index.css
@@ -128,7 +128,9 @@ mark {
   color: white;
   position: relative;
 }
-
+.tooltip {
+  @apply shadow-md shadow-zinc-400 after:absolute after:bottom-full after:left-12 after:border-x-[6px] after:border-b-[10px] after:border-transparent after:border-b-custom-gray-dark after:content-[''];
+}
 @media screen and (min-width: 768px) {
   .mission-check-list {
     width: 342px;

--- a/src/store/useTooltipState.ts
+++ b/src/store/useTooltipState.ts
@@ -5,9 +5,9 @@ interface TooltipState {
   setShowTooltip: (tooltipStatus: boolean) => void;
 }
 
-const useKeywordTooltip = create<TooltipState>((set) => ({
+const useTooltipState = create<TooltipState>((set) => ({
   showTooltip: false,
   setShowTooltip: (tooltipStatus) => set({ showTooltip: tooltipStatus }),
 }));
 
-export default useKeywordTooltip;
+export default useTooltipState;


### PR DESCRIPTION
### Details
- 홈 페이지에서 단어 툴팁 잔상 이슈가 발생하여 툴팁 위치를 단어 하단에 위치하도록 변경
- 직관적인 네이밍을 위하여 useKeywordTooltip -> useTooltipState으로 이름 변경
![image](https://github.com/user-attachments/assets/8ac949ad-8798-4c1b-9a07-a78a9e0c3c01)
