### PR TITLE
[refactor] 리페치 코드를 쿼리 무효화로 변경

### DIFF
--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -1,7 +1,6 @@
 import { Outlet } from 'react-router-dom';
 import Header from '../header/Header';
 import Footer from '../Footer';
-import TrackRoute from '../TrackRoute';
 import LoginModal from '../LoginModal';
 import LoginConfirmModal from '../LoginConfirmModal';
 
@@ -15,7 +14,6 @@ export default function Layout() {
         </main>
         <Footer />
       </div>
-      <TrackRoute />
       <LoginModal />
       <LoginConfirmModal />
     </>

--- a/src/components/common/layout/NewsDetailLayout.tsx
+++ b/src/components/common/layout/NewsDetailLayout.tsx
@@ -1,6 +1,5 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import Header from '../header/Header';
-import TrackRoute from '../TrackRoute';
 import Toast from '../Toast';
 import LoginModal from '../LoginModal';
 import LoginConfirmModal from '../LoginConfirmModal';
@@ -17,7 +16,6 @@ export default function NewsDetailLayout() {
           <Outlet />
         </main>
       </div>
-      <TrackRoute />
       <Toast />
       <LoginModal />
       <LoginConfirmModal />

--- a/src/components/common/layout/QuizLayout.tsx
+++ b/src/components/common/layout/QuizLayout.tsx
@@ -1,6 +1,5 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import Header from '../header/Header';
-import TrackRoute from '../TrackRoute';
 import LoginModal from '../LoginModal';
 import LoginConfirmModal from '../LoginConfirmModal';
 
@@ -16,7 +15,6 @@ export default function QuizLayout() {
           <Outlet />
         </main>
       </div>
-      <TrackRoute />
       <LoginModal />
       <LoginConfirmModal />
     </>

--- a/src/components/myWordList/Words/Bookmark.tsx
+++ b/src/components/myWordList/Words/Bookmark.tsx
@@ -15,7 +15,7 @@ export default function Bookmark({
   setShowModal: Dispatch<SetStateAction<boolean>>;
 }) {
   const { definition, term, description } = word.dictionary;
-  const { cancelBookmark } = useCancelBookmark(word.bookmarkId, activeMenu);
+  const { cancelBookmark } = useCancelBookmark(word.bookmarkId);
   const { setDefinition, setDescription } = useWordStore();
   const cleanedText = definition.replace(/<\/?mark>/g, '');
 

--- a/src/components/myWordList/Words/Bookmark.tsx
+++ b/src/components/myWordList/Words/Bookmark.tsx
@@ -1,4 +1,3 @@
-import { MyWordListMenuType } from '@/types/types';
 import { BookmarkDictionary } from '@/types/interface';
 import useCancelBookmark from '@/hooks/myWordList/api/useCancelBookmark';
 import arrowRightIcon from '@/assets/p2/arrow_right.png';
@@ -6,11 +5,9 @@ import { Dispatch, SetStateAction } from 'react';
 import useWordStore from '@/store/useWordStore';
 
 export default function Bookmark({
-  activeMenu,
   word,
   setShowModal,
 }: {
-  activeMenu: MyWordListMenuType;
   word: BookmarkDictionary;
   setShowModal: Dispatch<SetStateAction<boolean>>;
 }) {

--- a/src/components/myWordList/Words/History.tsx
+++ b/src/components/myWordList/Words/History.tsx
@@ -1,4 +1,3 @@
-import { MyWordListMenuType } from '@/types/types';
 import { HistoryDictionary } from '@/types/interface';
 import arrowRightIcon from '@/assets/p2/arrow_right.png';
 import { Dispatch, SetStateAction } from 'react';
@@ -10,7 +9,6 @@ export default function History({
   word,
   setShowModal,
 }: {
-  activeMenu: MyWordListMenuType;
   word: HistoryDictionary;
   setShowModal: Dispatch<SetStateAction<boolean>>;
 }) {

--- a/src/components/myWordList/Words/WordListContent.tsx
+++ b/src/components/myWordList/Words/WordListContent.tsx
@@ -26,22 +26,10 @@ export default function WordListContent({
 
       switch (activeMenu) {
         case '히스토리':
-          return (
-            <History
-              activeMenu={activeMenu}
-              word={word as HistoryDictionary}
-              key={key}
-              setShowModal={setShowModal}
-            />
-          );
+          return <History word={word as HistoryDictionary} key={key} setShowModal={setShowModal} />;
         case '북마크':
           return (
-            <Bookmark
-              activeMenu={activeMenu}
-              word={word as BookmarkDictionary}
-              key={key}
-              setShowModal={setShowModal}
-            />
+            <Bookmark word={word as BookmarkDictionary} key={key} setShowModal={setShowModal} />
           );
         case '졸업노트':
         case '오답노트':

--- a/src/hooks/myWordList/api/useCancelBookmark.ts
+++ b/src/hooks/myWordList/api/useCancelBookmark.ts
@@ -12,15 +12,12 @@ export default function useCancelBookmark(bookmarkId: number) {
       if (!isLogin) throw new Error();
       await bookmarkApi.removeBookmark(bookmarkId);
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.getHistoryList,
-      });
-      await queryClient.invalidateQueries({
+    onSuccess: () => {
+      queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.getBookmarkList,
       });
-      await queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.learningStatus,
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.getHistoryList,
       });
     },
   });

--- a/src/hooks/myWordList/api/useCancelBookmark.ts
+++ b/src/hooks/myWordList/api/useCancelBookmark.ts
@@ -1,16 +1,11 @@
 import { useLoginStore } from '@/store/useIsLoginStore';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import QUERY_KEYS from '@/constants/queryKeys';
-import { MyWordListMenuType } from '@/types/types';
-import useGetWordListData from './useGetWordListData';
-import useLearningStatus from './useLearningStatus';
 import bookmarkApi from '@/services/bookmarkApi';
 
-export default function useCancelBookmark(bookmarkId: number, activeMenu: MyWordListMenuType) {
+export default function useCancelBookmark(bookmarkId: number) {
   const { isLogin } = useLoginStore();
   const queryClient = useQueryClient();
-  const { refetch } = useGetWordListData(activeMenu);
-  const { refetchStatus } = useLearningStatus();
 
   const mutation = useMutation({
     mutationFn: async () => {
@@ -21,8 +16,12 @@ export default function useCancelBookmark(bookmarkId: number, activeMenu: MyWord
       await queryClient.invalidateQueries({
         queryKey: QUERY_KEYS.getHistoryList,
       });
-      refetch();
-      refetchStatus();
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.getBookmarkList,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.learningStatus,
+      });
     },
   });
 

--- a/src/hooks/myWordList/api/useLearningStatus.ts
+++ b/src/hooks/myWordList/api/useLearningStatus.ts
@@ -1,7 +1,7 @@
 import wordListAPi from '@/services/wordListApi';
 import { useQuery } from '@tanstack/react-query';
-import historyApi from '@/services/historyApi';
 import QUERY_KEYS from '@/constants/queryKeys';
+import useGetWordListData from './useGetWordListData';
 
 export default function useLearningStatus() {
   const {
@@ -13,17 +13,9 @@ export default function useLearningStatus() {
     queryFn: wordListAPi.getLearningStatus,
   });
 
-  const {
-    data: history,
-    refetch: refetchHistory,
-    isLoading: isHistoryLoading,
-  } = useQuery({
-    queryKey: QUERY_KEYS.getHistoryList,
-    queryFn: historyApi.getHistory,
-  });
-
+  const { wordList, isLoading: isHistoryLoading } = useGetWordListData('히스토리');
   const { username = '', totalScrap = 0, totalGraduation = 0, accuracyRate = 0 } = userInfo ?? {};
-  const { historyCnt = 0 } = history ?? {};
+  const historyCnt = wordList.length;
 
   return {
     username,
@@ -33,7 +25,6 @@ export default function useLearningStatus() {
     refetchStatus,
     isStatusLoading,
     historyCnt,
-    refetchHistory,
     isHistoryLoading,
   };
 }

--- a/src/hooks/myWordList/api/useLearningStatus.ts
+++ b/src/hooks/myWordList/api/useLearningStatus.ts
@@ -9,7 +9,7 @@ export default function useLearningStatus() {
     refetch: refetchStatus,
     isLoading: isStatusLoading,
   } = useQuery({
-    queryKey: ['learningStatus'],
+    queryKey: QUERY_KEYS.learningStatus,
     queryFn: wordListAPi.getLearningStatus,
   });
 

--- a/src/hooks/newDetail/useBookmarkWord.ts
+++ b/src/hooks/newDetail/useBookmarkWord.ts
@@ -2,12 +2,10 @@ import QUERY_KEYS from '@/constants/queryKeys';
 import bookmarkApi from '@/services/bookmarkApi';
 import { BookMark } from '@/types/interface';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import useGetWordListData from '@/hooks/myWordList/api/useGetWordListData';
 import { AxiosError } from 'axios';
 
 const useBookmarkWord = () => {
   const queryClient = useQueryClient();
-  const { refetch } = useGetWordListData('히스토리');
   const { mutate, isPending } = useMutation({
     mutationFn: async (wordId: number) => await bookmarkApi.addBookmark(wordId),
     onMutate: async (data) => {
@@ -34,9 +32,14 @@ const useBookmarkWord = () => {
       }
       return queryClient.setQueryData(QUERY_KEYS.getBookmarkList, context?.prevData);
     },
-    onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.getBookmarkList });
-      refetch();
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.getBookmarkList,
+      });
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.getHistoryList,
+      });
     },
   });
   return { mutate, isPending };

--- a/src/hooks/newDetail/useBookmarkWord.ts
+++ b/src/hooks/newDetail/useBookmarkWord.ts
@@ -38,8 +38,6 @@ const useBookmarkWord = () => {
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.getBookmarkList });
       refetch();
     },
-    onSuccess: async () =>
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.learningStatus }),
   });
   return { mutate, isPending };
 };

--- a/src/hooks/newDetail/useRemoveBookmarkWord.ts
+++ b/src/hooks/newDetail/useRemoveBookmarkWord.ts
@@ -2,11 +2,9 @@ import QUERY_KEYS from '@/constants/queryKeys';
 import bookmarkApi from '@/services/bookmarkApi';
 import { BookMark } from '@/types/interface';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import useGetWordListData from '../myWordList/api/useGetWordListData';
 
 const useRemoveBookmark = () => {
   const queryClient = useQueryClient();
-  const { refetch } = useGetWordListData('히스토리');
   const { mutate, isPending } = useMutation({
     mutationFn: async (bookmarkId: number) => await bookmarkApi.removeBookmark(bookmarkId),
     onMutate: async (bookmarkId) => {
@@ -31,7 +29,7 @@ const useRemoveBookmark = () => {
       queryClient.setQueryData(QUERY_KEYS.getBookmarkList, context?.prevData),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.getBookmarkList });
-      refetch();
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.getHistoryList });
     },
   });
 

--- a/src/hooks/newDetail/useRemoveBookmarkWord.ts
+++ b/src/hooks/newDetail/useRemoveBookmarkWord.ts
@@ -33,8 +33,6 @@ const useRemoveBookmark = () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.getBookmarkList });
       refetch();
     },
-
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.learningStatus }),
   });
 
   return { mutate, isPending };

--- a/src/pages/quiz/QuizResultPage.tsx
+++ b/src/pages/quiz/QuizResultPage.tsx
@@ -7,9 +7,10 @@ import NormalQuizResultCard from '@/components/quiz/quizResult/NormalQuizResultC
 import { useUserInfoQuery } from '@/hooks/auth/useUserInfoQuery';
 import MissionCheckComponent from '@/components/common/MissionCheckComponent';
 import { useEffect } from 'react';
-import useGetWordListData from '@/hooks/myWordList/api/useGetWordListData';
 import { useLocation, useNavigate } from 'react-router-dom';
 import ImgContainer from '@/components/common/ImgContainer';
+import QUERY_KEYS from '@/constants/queryKeys';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function QuizResultPage() {
   const location = useLocation();
@@ -26,10 +27,7 @@ export default function QuizResultPage() {
   const { data } = useUserInfoQuery(!isGraduate);
   const title = createTitle(accuracyRate, isGraduate, !isGraduate ? data?.name : undefined);
 
-  const { refetch: refetchScrap } = useGetWordListData('히스토리');
-  const { refetch: refetchWrongNote } = useGetWordListData('오답노트');
-  const { refetch: refetchGradNote } = useGetWordListData('졸업노트');
-
+  const queryClient = useQueryClient();
   useEffect(() => {
     return () => {
       localStorage.removeItem(NORMAL_QUIZ_RESULT_KEY);
@@ -37,9 +35,15 @@ export default function QuizResultPage() {
   }, [location]);
 
   useEffect(() => {
-    refetchScrap();
-    refetchWrongNote();
-    refetchGradNote();
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.getGradList,
+    });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.getHistoryList,
+    });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.getWrongList,
+    });
   }, []);
   return (
     <div className='m-auto'>

--- a/src/pages/quiz/randomQuiz/RandomQuizResultPage.tsx
+++ b/src/pages/quiz/randomQuiz/RandomQuizResultPage.tsx
@@ -8,17 +8,26 @@ import { RANDOM_QUIZ_RESULT_KEY } from '@/constants/constants';
 import { IQuizResult } from '@/types/interface';
 import MissionCheckComponent from '@/components/common/MissionCheckComponent';
 import { useEffect } from 'react';
-
+import { useQueryClient } from '@tanstack/react-query';
+import QUERY_KEYS from '@/constants/queryKeys';
 export default function RandomQuizResultPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const results: IQuizResult = JSON.parse(localStorage.getItem(RANDOM_QUIZ_RESULT_KEY) as string);
 
+  const queryClient = useQueryClient();
   useEffect(() => {
     return () => {
       localStorage.removeItem(RANDOM_QUIZ_RESULT_KEY);
     };
   }, [location]);
+
+  useEffect(() => {
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.getHistoryList,
+    });
+  }, []);
+
   return (
     <div className='m-auto'>
       <div className='mb-[16px] mt-[40px] text-center'>


### PR DESCRIPTION
### Details
- **TrackRoute**는 이전 콘텐츠 상세 페이지와 관련되어 있던 것이라 **레이아웃에서 제거**하였습니다.
- **refetch** 사용했던 것들을 **쿼리 무효화로 변경**하였습니다.
- 여러 개의 쿼리 무효화시 배열로 묶어서 무효화하려 했지만 참고에 있는 링크에서도 언급했다시피 **쿼리키 배열**로 쿼리 무효화에 어려움이 있습니다.
- 배포 비용 감소를 위해 바로 main 브랜치에 머지하는 대신 **develop 브랜치**를 생성해 머지 후  main 브랜치로 머지하겠습니다.
### reference
https://github.com/TanStack/query/issues/4669
